### PR TITLE
Fixed Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,26 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
-    name: "GTForceTouchGestureRecognizer"
+    name: "GTForceTouchGestureRecognizer",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "GTForceTouchGestureRecognizer",
+            targets: ["GTForceTouchGestureRecognizer"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "GTForceTouchGestureRecognizer",
+            path: "Sources",
+            sources: [
+                "."
+            ]
+        )
+    ]
 )

--- a/Sources/GTForceTouchGestureRecognizerInternal.swift
+++ b/Sources/GTForceTouchGestureRecognizerInternal.swift
@@ -26,7 +26,7 @@ import UIKit.UIGestureRecognizerSubclass
 
 internal extension GTForceTouchGestureRecognizer {
     
-    internal func handleTouch(_ touch: UITouch?) {
+    func handleTouch(_ touch: UITouch?) {
         guard view != nil, let touch = touch, touch.force != 0 && touch.maximumPossibleForce != 0 else {
             return
         }


### PR DESCRIPTION
Fix for Package.swift
Removed internal declaration from handleTouch to remove compile warning